### PR TITLE
Feature/it201 b fix credentials aws 

### DIFF
--- a/src/scripts-aws/ses/configSes.js
+++ b/src/scripts-aws/ses/configSes.js
@@ -4,11 +4,38 @@ const AWS = require('aws-sdk');
 // Set the Region 
 AWS.config.update({region: 'us-east-1'});
 
+// Obsoleto
+// AWS.config.update({
+//     accessKeyId: "te la creiste wey",
+//     secretAccessKey: "te la creiste wey x2",
+//     "region": "us-east-1"
+// });
 
-AWS.config.update({
-    accessKeyId: "te la creiste wey",
-    secretAccessKey: "te la creiste wey x2",
-    "region": "us-east-1"
-});
+
+
+//Cargando las credenciales de manera local OJO -> esto no sirve para deplyment.
+
+//Como Hacerlo
+//Tener un archivo llamado "credentials" tipo "FILE" en la ruta (...)/usuario_actual/.aws/
+//este archivo debe tener el siguiente contenido
+
+// [default] ; default profile
+// aws_access_key_id = <DEFAULT_ACCESS_KEY_ID>
+// aws_secret_access_key = <DEFAULT_SECRET_ACCESS_KEY>
+    
+// [personal-account] ; personal account profile
+// aws_access_key_id = <PERSONAL_ACCESS_KEY_ID>
+// aws_secret_access_key = <PERSONAL_SECRET_ACCESS_KEY>
+    
+// [work-account] ; work account profile
+// aws_access_key_id = <WORK_ACCESS_KEY_ID>
+// aws_secret_access_key = <WORK_SECRET_ACCESS_KEY></WORK_SECRET_ACCESS_KEY>
+
+//Con lo siguiente simplemente se carga el archivo
+//recuerde estar trabajando en un entorno de node y aws
+
+const credentials = new AWS.SharedIniFileCredentials({profile: 'work-account'});
+AWS.config.credentials = credentials;
+
 
 module.exports = AWS

--- a/src/services/aws.js
+++ b/src/services/aws.js
@@ -4,11 +4,12 @@ const AWS = require('aws-sdk');
 // Set the Region 
 AWS.config.update({region: 'us-east-1'});
 
+//En este caso las credenciales se cargan desde EB usando un rol
 
-AWS.config.update({
-    accessKeyId: "Consulte con Gabriel Avendano Casadiego",
-    secretAccessKey: "Consulte con Camilo Andres Gil Ballen",
-    "region": "us-east-1"
-});
+//Se crea un rol con todos los permisos necesarios
+
+//En el entorno, en la parte de configuracion -> seguridad -> Se selecciona dicho rol
+
+//Automaticamente se caragaran todas las credenciales
 
 module.exports = AWS


### PR DESCRIPTION
Se añadieron las credenciales AWS de manera segura:

Para los script's se deben tener credenciales locales.

Para los demás servicios se gestiono usando un rol (Tuttore_leader) y asignándoselo a la instancia en EC2. 

Esto quiere decir que las credenciales de estaran en el pc del usuario (cuando se ejecutan scripts locales) o seran solicitados por la instancia diferentamente al rol. 
